### PR TITLE
Update mocha-jsdom version

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,14 +27,14 @@
     "expect": "^1.20.2",
     "jsdom": "^9.3.0",
     "mocha": "^2.5.3",
-    "mocha-jsdom": "^1.1.0",
+    "mocha-jsdom": "2.0.0",
     "mocha-multi": "^0.9.0"
   },
   "dependencies": {
     "expect": "^1.20.2",
     "jsdom": "^9.4.1",
     "mocha": "^2.5.3",
-    "mocha-jsdom": "^1.1.0",
+    "mocha-jsdom": "2.0.0",
     "sinon": "^1.17.4"
   }
 }


### PR DESCRIPTION
This update should take care of the below error that students are seeing when they run `learn`.

"before all" hook:
    Error: Cannot find module 'jsdom/lib/old-api'
     at require (internal/module.js:11:18)
     at Context.<anonymous> (node_modules/mocha-jsdom/index.js:53:5)